### PR TITLE
Issue 11/unrecognized token response field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.4.1 (2026-07-03)
+
+### Fixed
+
+- Ignore unrecognized fields in token responses.
+
 ## 0.4.0 (2025-06-04)
 
 ### Added 
@@ -24,4 +30,3 @@
 ### Changed
 
 - OAuth2Client now requires a storage interface to be passed into the constructor
-

--- a/src/oauth2_client/oauth2_client.ml
+++ b/src/oauth2_client/oauth2_client.ml
@@ -103,7 +103,7 @@ type token_response = {
   expires_in: (int option [@default None]);
   refresh_token: (string option [@default None]);
   scope: (string option [@default None]);
-} [@@deriving yojson { strict = false }]
+} [@@deriving yojson { strict = false }] (* Client must ignore unrecognized fields, per https://datatracker.ietf.org/doc/html/rfc6749#section-5.1 *)
 
 type token_error_code =
   | Invalid_Request

--- a/src/oauth2_client/oauth2_client.ml
+++ b/src/oauth2_client/oauth2_client.ml
@@ -103,7 +103,7 @@ type token_response = {
   expires_in: (int option [@default None]);
   refresh_token: (string option [@default None]);
   scope: (string option [@default None]);
-} [@@deriving yojson]
+} [@@deriving yojson { strict = false }]
 
 type token_error_code =
   | Invalid_Request
@@ -422,4 +422,3 @@ module OAuth2Client (Storage : Storage.STORAGE_UNIT with type value = (string * 
     | _ -> failwith "Device token polling only available for Device Code flow"
  *)  
 end
-

--- a/src/oauth2_client/oauth2_client.mli
+++ b/src/oauth2_client/oauth2_client.mli
@@ -65,7 +65,7 @@ type token_response = {
   expires_in: int option;
   refresh_token: string option;
   scope: string option;
-} [@@deriving yojson { strict = false }]
+} [@@deriving yojson { strict = false }] (* Client must ignore unrecognized fields, per https://datatracker.ietf.org/doc/html/rfc6749#section-5.1 *)
 
 type device_code_response = {
   device_code: string;

--- a/src/oauth2_client/oauth2_client.mli
+++ b/src/oauth2_client/oauth2_client.mli
@@ -65,7 +65,7 @@ type token_response = {
   expires_in: int option;
   refresh_token: string option;
   scope: string option;
-} [@@deriving yojson]
+} [@@deriving yojson { strict = false }]
 
 type device_code_response = {
   device_code: string;
@@ -91,4 +91,3 @@ sig
 end
 
 module OAuth2Client (_ : Storage.STORAGE_UNIT with type value = (string * config)) : OAUTH2_CLIENT
-

--- a/test/test_savvy.ml
+++ b/test/test_savvy.ml
@@ -9,6 +9,27 @@ module GitHubInMemoryStorage = Storage.MakeInMemoryStorage(GitHubInMemoryStorage
 module GitHub = GitHubClient(GitHubInMemoryStorage)
 
 let () =
+  let json =
+    Yojson.Safe.from_string
+      {|{
+        "access_token":"abc",
+        "token_type":"Bearer",
+        "expires_in":3600,
+        "refresh_token":"xyz",
+        "unknown_field":"ignored",
+        "scope":"read"
+      }|}
+  in
+  match Oauth2_client.token_response_of_yojson json with
+  | Ok token ->
+    assert (token.access_token = "abc");
+    assert (token.token_type = "Bearer");
+    assert (token.expires_in = Some 3600);
+    assert (token.refresh_token = Some "xyz");
+    assert (token.scope = Some "read")
+  | Error message -> failwith ("Unexpected token response parse failure: " ^ message)
+
+let () =
   print_endline "===========================================================================";
   print_endline "Most secure Auth Code Setup";
   let config = Oauth2_client.AuthorizationCodeConfig {
@@ -153,4 +174,3 @@ let () =
   match GitHub.get_authorization_url ~config with
   | Ok (url, _state) -> Printf.printf "Auth URL: %s\n Generated State: %s\n\n\n" (Uri.to_string url) _state
   | Error message -> failwith ("THIS SHOULD HAVE WORKED: " ^ message)
-


### PR DESCRIPTION
Fixes Issue #11  

Per [RFC-6749 section 5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1), The client MUST ignore unrecognized value names in the response.

This PR updates the yojson parsing to be loose and ignore unrecognized fields as expected. I also added a test to verify this case for builds.

Verified also in utop:

Expected response works:

```
utop # let json =
  Yojson.Safe.from_string
    {|{
      "access_token":"abc",
      "token_type":"Bearer",
      "expires_in":3600,
      "refresh_token":"xyz",
      "scope":"read"
    }|} in Oauth2_client.token_response_of_yojson json;;
- : Oauth2_client.token_response Ppx_deriving_yojson_runtime.error_or =
Ok
 {Oauth2_client.access_token = "abc"; token_type = "Bearer";
  expires_in = Some 3600; refresh_token = Some "xyz"; scope = Some "read"}
```

Response with unexpected field works:

```
utop # let json =
  Yojson.Safe.from_string
    {|{
      "access_token":"abc",
      "token_type":"Bearer",
      "expires_in":3600,
      "refresh_token":"xyz",
      "created_at": 12345,
      "scope":"read"
    }|} in Oauth2_client.token_response_of_yojson json;;
- : Oauth2_client.token_response Ppx_deriving_yojson_runtime.error_or =
Ok
 {Oauth2_client.access_token = "abc"; token_type = "Bearer";
  expires_in = Some 3600; refresh_token = Some "xyz"; scope = Some "read"}
```

